### PR TITLE
Fix: Cast shift operand to uint to comply with Go's type requirements

### DIFF
--- a/alaw.go
+++ b/alaw.go
@@ -92,7 +92,7 @@ func EncodeAlawFrame(frame int16) uint8 {
 	compressedByte = frame >> 4
 	if compressedByte > 15 {
 		seg = int16(12 - bits.LeadingZeros16(uint16(compressedByte)))
-		compressedByte >>= seg - 1
+		compressedByte >>= uint(seg - 1)
 		compressedByte -= 16
 		compressedByte += seg << 4
 	}

--- a/ulaw.go
+++ b/ulaw.go
@@ -99,7 +99,7 @@ func EncodeUlawFrame(frame int16) uint8 {
 		frame = ulawClip
 	}
 	seg = int16(16 - bits.LeadingZeros16(uint16(frame>>5)))
-	lowNibble = 0x000F - ((frame >> (seg)) & 0x000F)
+	lowNibble = 0x000F - ((frame >> uint(seg)) & 0x000F)
 	return uint8(sign | ((8 - seg) << 4) | lowNibble)
 }
 


### PR DESCRIPTION
## Description
### Problem
The current implementation of the `alaw.go` and `ulaw.go` files uses `int16` type for shift operations, which causes compilation errors in newer versions of Go. The error messages are as follows:

```
../../go/src/github.com/zaf/g711/alaw.go:95:18: invalid operation: compressedByte >>= seg - 1 (shift count type int16, must be unsigned integer)
../../go/src/github.com/zaf/g711/ulaw.go:102:24: invalid operation: frame >> seg (shift count type int16, must be unsigned integer)
```

### Solution
This pull request addresses the issue by casting the shift operands to `uint`, ensuring compliance with Go's requirement for unsigned integer types in shift operations.

### Changes
1. In `alaw.go`:
   ```go
   // Before: compressedByte >>= seg - 1
   // After:
   compressedByte >>= uint(seg - 1)
   ```

2. In `ulaw.go`:
   ```go
   // Before: frame >> seg
   // After:
   frame >> uint(seg)
   ```

### Impact
These changes resolve the compilation errors without altering the logic of the code. It ensures compatibility with current and future versions of Go that enforce stricter type checking for shift operations.

### Testing
The modifications have been tested locally, and the package now compiles successfully without any errors related to shift operations.

### Additional Notes
This fix is necessary for users trying to use this package with recent Go versions. It maintains the original functionality while adhering to Go's language specifications.

---

I appreciate your time in reviewing this pull request. Please let me know if you need any further information or if you'd like me to make any additional changes.